### PR TITLE
feat: add option to track and autotrack userId

### DIFF
--- a/Sources/LogSnag/LogSnag.swift
+++ b/Sources/LogSnag/LogSnag.swift
@@ -49,6 +49,11 @@ public class LogSnagClient {
         var options = options
         options.project = project
         
+        if options.autoAddUserId == true, options.userId == nil  {
+            options.userId = generateOrRetrieveUserId()
+            options.autoAddUserId = nil
+        }
+        
         request.httpBody = try? jsonEncoder.encode(options)
         
         return request
@@ -71,5 +76,17 @@ public class LogSnagClient {
     /// - Returns: Combine `Publisher`
     public func publish(options: PublishOptions) -> AnyPublisher<Bool, Error> {
         dataClient.dataTaskPublisher(for: request(options: options))
+    }
+    
+    private func generateOrRetrieveUserId() -> String {
+        // Retrieve the user ID if it's already been generated.
+        if let existingId = UserDefaults.standard.string(forKey: "logSnagUserId") {
+            return existingId
+        } else {
+            // Generate a new user ID if one does not exist, then store it for future use.
+            let newId = UUID().uuidString
+            UserDefaults.standard.setValue(newId, forKey: "logSnagUserId")
+            return newId
+        }
     }
 }

--- a/Sources/LogSnag/Publish.swift
+++ b/Sources/LogSnag/Publish.swift
@@ -8,6 +8,8 @@ public struct PublishOptions: Codable, Equatable {
     let icon: String?
     let notify: Bool?
     var project: String?
+    var userId: String?
+    var autoAddUserId: Bool?
     
     /// Creates a `PublishOptions` object to send to LogSnag
     /// - Parameters:
@@ -16,17 +18,29 @@ public struct PublishOptions: Codable, Equatable {
     ///   - description: Event description (default `nil`)
     ///   - icon: Event icon (emoji)  (default `nil`)
     ///   - notify: Send push notification  (default `nil`)
+    ///   - userId: User ID  (default `nil`)
+    ///   - autoAddUserId: Automatically add user ID to event  (default `nil`)
     public init(
         channel: String,
         event: String,
         description: String? = nil,
         icon: String? = nil,
-        notify: Bool? = nil
+        notify: Bool? = nil,
+        userId: String? = nil,
+        autoAddUserId: Bool? = nil
     ) {
         self.channel = channel
         self.event = event
         self.description = description
         self.icon = icon
         self.notify = notify
+        self.userId = userId
+        self.autoAddUserId = autoAddUserId
     }
+    
+    enum CodingKeys: String, CodingKey {
+         case channel, description, event, icon, notify, project
+         case userId = "user_id"
+         case autoAddUserId
+     }
 }


### PR DESCRIPTION
Hey :) 

Thanks for providing the library.

LogSnag implements a special `user_id` field that can be used to track the user. 

In this PR i added the option to pass the user `user_id` and also the automatically track the current user using UserDefaults.

The auto-tracking implementation is a bit far-fetched. Let me know what you think :) 
 